### PR TITLE
EPICS Server Fix

### DIFF
--- a/virtaccl/EPICS_Server/ca_server.py
+++ b/virtaccl/EPICS_Server/ca_server.py
@@ -26,7 +26,8 @@ def add_epics_arguments(va_parser: VA_Parser) -> VA_Parser:
                                   help='Number (in seconds) that determine some delay parameter in the server. Not '
                                        'exactly sure how it works, so use at your own risk.')
 
-    va_parser.add_server_argument('--print_pvs', dest='print_pvs', action='store_true',
+    va_parser.remove_argument('--print_server_keys')
+    va_parser.add_va_argument('--print_pvs', dest='print_server_keys', action='store_true',
                                   help="Will print all server PVs. Will NOT run the virtual accelerator.")
     return va_parser
 
@@ -58,12 +59,11 @@ class TDriver(Driver):
 
 
 class EPICS_Server(Server):
-    def __init__(self, prefix='', process_delay=0.1, print_pvs=False):
+    def __init__(self, prefix='', process_delay=0.1):
         super().__init__()
         self.prefix = prefix
         self.driver = None
         self.process_delay = process_delay
-        self.print_pvs = print_pvs
         self.start_flag = False
 
         os.environ['EPICS_CA_MAX_ARRAY_BYTES'] = '10000000'
@@ -71,13 +71,6 @@ class EPICS_Server(Server):
     def _CA_events(self, server):
         while True:
             server.process(self.process_delay)
-
-    def add_parameters(self, new_parameters: Dict[str, Dict[str, Any]]):
-        super().add_parameters(new_parameters)
-        if self.print_pvs:
-            for key in self.get_parameter_keys():
-                print(key)
-            sys.exit()
 
     def set_parameter(self, reason: str, value: Any, timestamp: datetime = None):
         super().set_parameter(reason, value, timestamp)

--- a/virtaccl/EPICS_Server/ca_server.py
+++ b/virtaccl/EPICS_Server/ca_server.py
@@ -23,9 +23,8 @@ def add_epics_arguments(va_parser: VA_Parser) -> VA_Parser:
 
     va_parser.remove_argument('--print_server_keys')
     va_parser.add_va_argument('--print_pvs', dest='print_server_keys', action='store_true',
-                                  help="Will print all server PVs. Will NOT run the virtual accelerator.")
+                              help="Will print all server PVs. Will NOT run the virtual accelerator.")
     return va_parser
-
 
 
 class EPICS_Server(Server):

--- a/virtaccl/beam_line.py
+++ b/virtaccl/beam_line.py
@@ -501,3 +501,7 @@ class BeamLine:
             for reason in device.readbacks:
                 readback_keys.append(device.get_parameter(reason).get_server_key())
         return readback_keys
+
+    def get_all_keys(self) -> List[str]:
+        server_keys = self.get_setting_keys() + self.get_measurement_keys() + self.get_readback_keys()
+        return server_keys

--- a/virtaccl/site/BTF/btf_virtual_accelerator.py
+++ b/virtaccl/site/BTF/btf_virtual_accelerator.py
@@ -301,7 +301,7 @@ def build_btf(**kwargs):
             beam_line.add_device(slit_device)
 
     delay = kwargs['ca_proc']
-    server = EPICS_Server(process_delay=delay, print_pvs=kwargs['print_pvs'])
+    server = EPICS_Server(process_delay=delay)
 
     btf_virac = PyorbitVirtualAcceleratorBuilder(model, beam_line, server, **kwargs)
     return btf_virac

--- a/virtaccl/site/SNS_IDmp/IDmp_virtual_accelerator.py
+++ b/virtaccl/site/SNS_IDmp/IDmp_virtual_accelerator.py
@@ -125,7 +125,7 @@ def build_idmp(**kwargs):
     beam_line.add_device(dummy_device)
 
     delay = kwargs['ca_proc']
-    server = EPICS_Server(process_delay=delay, print_pvs=kwargs['print_pvs'])
+    server = EPICS_Server(process_delay=delay)
 
     idmp_virac = PyorbitVirtualAcceleratorBuilder(model, beam_line, server, **kwargs)
     return idmp_virac

--- a/virtaccl/site/SNS_Linac/virtual_SNS_linac.py
+++ b/virtaccl/site/SNS_Linac/virtual_SNS_linac.py
@@ -231,7 +231,7 @@ def build_sns(**kwargs):
     beam_line.add_device(dummy_device)
 
     delay = kwargs['ca_proc']
-    server = EPICS_Server(process_delay=delay, print_pvs=kwargs['print_pvs'])
+    server = EPICS_Server(process_delay=delay)
 
     sns_virac = PyorbitVirtualAcceleratorBuilder(model, beam_line, server, **kwargs)
     return sns_virac

--- a/virtaccl/virtual_accelerator.py
+++ b/virtaccl/virtual_accelerator.py
@@ -141,12 +141,12 @@ class VirtualAcceleratorBuilder(Generic[ModelType, ServerType]):
     def get_server(self) -> ServerType:
         return self.server
 
-    def build(self) -> 'VirtualAccelerator':
+    def build(self) -> 'VirtualAccelerator[ModelType, ServerType]':
         return VirtualAccelerator(self.model, self.beam_line, self.server, **self.options)
 
 
-class VirtualAccelerator:
-    def __init__(self, model: Model, beam_line: BeamLine, server: Server, **kwargs):
+class VirtualAccelerator(Generic[ModelType, ServerType]):
+    def __init__(self, model: ModelType, beam_line: BeamLine, server: ServerType, **kwargs):
         if not kwargs:
             kwargs = VA_Parser().initialize_arguments()
 

--- a/virtaccl/virtual_accelerator.py
+++ b/virtaccl/virtual_accelerator.py
@@ -113,6 +113,9 @@ def add_va_arguments(va_parser: VA_Parser) -> VA_Parser:
     va_parser.add_va_argument('--production', dest='debug', action='store_false',
                               help="DEFAULT: No additional info printed.")
 
+    va_parser.add_server_argument('--print_server_keys', action='store_true',
+                                  help="Will print all server keys for the server. Will NOT run the virtual "
+                                       "accelerator.")
     va_parser.add_server_argument('--print_settings', action='store_true',
                                   help="Will only print setting keys for the server. Will NOT run the virtual "
                                        "accelerator.")
@@ -152,6 +155,11 @@ class VirtualAccelerator(Generic[ModelType, ServerType]):
 
         if kwargs['print_settings']:
             for key in beam_line.get_setting_keys():
+                print(key)
+            sys.exit()
+
+        if kwargs['print_server_keys']:
+            for key in beam_line.get_all_keys():
                 print(key)
             sys.exit()
 


### PR DESCRIPTION
The CA Server using PCASPY now only starts when server.start() is called. Otherwise, the PCASPY modules are never imported.